### PR TITLE
allow trailing period in fqdn

### DIFF
--- a/letsencrypt/le_util.py
+++ b/letsencrypt/le_util.py
@@ -315,6 +315,7 @@ def check_domain_sanity(domain):
     # http://www.mkyong.com/regular-expressions/domain-name-regular-expression-example/
     #  Characters used, domain parts < 63 chars, tld > 1 < 64 chars
     #  first and last char is not "-"
-    fqdn = re.compile("^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,63}$")
+    #  last character may be a "."
+    fqdn = re.compile("^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,63}.?$")
     if not fqdn.match(domain):
         raise errors.ConfigurationError("Requested domain is not a FQDN")


### PR DESCRIPTION
updated `check_domain_sanity()` regex to allow for trailing period.
